### PR TITLE
fix cast for 64bit pointers

### DIFF
--- a/src/iostream/ostream.h
+++ b/src/iostream/ostream.h
@@ -202,7 +202,7 @@ class ostream : public virtual ios {
    * \return the stream
    */
   ostream &operator<<(const void *arg) {
-    putNum(reinterpret_cast<uint32_t>(arg));
+    putNum(reinterpret_cast<uintptr_t>(arg));
     return *this;
   }
   /** Output a string from flash using the Arduino F() macro.


### PR DESCRIPTION
Compiling the SdFat library on a 64bit system leads to compiler errors:

```
In file included from .pio/libdeps/native-tft/SdFat/src/iostream/iostream.h:32,
                 from .pio/libdeps/native-tft/SdFat/src/iostream/fstream.h:30,
                 from .pio/libdeps/native-tft/SdFat/src/iostream/StreamBaseClass.cpp:25:
.pio/libdeps/native-tft/SdFat/src/iostream/ostream.h: In member function ‘ostream& ostream::operator<<(const void*)’:
.pio/libdeps/native-tft/SdFat/src/iostream/ostream.h:205:12: error: cast from ‘const void*’ to ‘uint32_t’ {aka ‘unsigned int’} loses precision [-fpermissive]
  205 |     putNum(reinterpret_cast<uint32_t>(arg));
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
*** [.pio/build/native-tft/lib007/SdFat/iostream/StreamBaseClass.cpp.o] Error 1
```

Reason is a 64bit void* is casted to 32bit.


This PR fixes this issue by using the standard pointer type `uintptr_t` that always uses the right size for the platform.